### PR TITLE
feat: comprehensive project improvements

### DIFF
--- a/.github/workflows/php-unit.yaml
+++ b/.github/workflows/php-unit.yaml
@@ -1,19 +1,59 @@
-name: PHPUnit
+name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-  build-test:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: ['8.1', '8.2', '8.3', '8.4']
+
+    name: PHP ${{ matrix.php-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: xdebug
+
+      - uses: php-actions/composer@v6
+
+      - name: PHPUnit Tests
+        run: vendor/bin/phpunit
+
+  phpstan:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
       - uses: php-actions/composer@v6
 
-      - name: PHPUnit Tests
-        uses: php-actions/phpunit@v4
+      - name: PHPStan
+        run: vendor/bin/phpstan analyse
+
+  cs-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          bootstrap: vendor/autoload.php
-          configuration: phpunit.xml
-          args: --coverage-text
+          php-version: '8.3'
+
+      - uses: php-actions/composer@v6
+
+      - name: PHP CS Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build
 build/
 build/*
 
+# php-cs-fixer
+.php-cs-fixer.cache
+
 # composer
 composer.lock
 /vendor

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,14 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
-        "phpstan/phpstan": "^2.0"
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^10.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": "vendor/bin/phpunit",
+        "phpstan": "vendor/bin/phpstan analyse",
+        "cs-check": "vendor/bin/php-cs-fixer fix --dry-run --diff",
+        "cs-fix": "vendor/bin/php-cs-fixer fix"
     }
 }

--- a/example/cluster.php
+++ b/example/cluster.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use EJTJ3\PhpNats\Connection\NatsConnection;
+use EJTJ3\PhpNats\Connection\NatsConnectionOption;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// Connect to a cluster with multiple servers
+// The client will try each server in order until one succeeds
+$option = new NatsConnectionOption(
+    servers: [
+        'nats://admin:admin@nats-server0.example.com:4222',
+        'nats://admin:admin@nats-server1.example.com:4222',
+        'nats://admin:admin@nats-server2.example.com:4222',
+    ],
+    name: 'cluster example',
+    timeout: 5,
+    randomize: true, // randomize server order for load balancing
+);
+
+$connection = new NatsConnection($option);
+
+$connection->connect();
+
+if ($connection->isConnected()) {
+    $connection->publish('hello', 'world');
+}
+
+$connection->close();

--- a/example/request.php
+++ b/example/request.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use EJTJ3\PhpNats\Connection\NatsConnection;
+use EJTJ3\PhpNats\Connection\NatsConnectionOption;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$dsn = 'nats://admin:admin@0.0.0.0:4222';
+
+$option = new NatsConnectionOption($dsn, 'request example', 5);
+$connection = new NatsConnection($option);
+
+$connection->connect();
+
+if ($connection->isConnected()) {
+    $response = $connection->request('my.subject', 'request payload');
+
+    echo 'Response: ' . $response->getPayload() . PHP_EOL;
+}
+
+$connection->close();

--- a/example/subscribe.php
+++ b/example/subscribe.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use EJTJ3\PhpNats\Connection\MessageInterface;
+use EJTJ3\PhpNats\Connection\NatsConnection;
+use EJTJ3\PhpNats\Connection\NatsConnectionOption;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$dsn = 'nats://admin:admin@0.0.0.0:4222';
+
+$option = new NatsConnectionOption($dsn, 'subscribe example', 5);
+$connection = new NatsConnection($option);
+
+$connection->connect();
+
+if ($connection->isConnected()) {
+    $subscription = $connection->subscribe('my.subject');
+
+    echo 'Waiting for messages on "my.subject"...' . PHP_EOL;
+
+    // Wait for a message
+    $msg = $connection->getMsg();
+
+    if ($msg instanceof MessageInterface) {
+        echo 'Received: ' . $msg->getPayload() . PHP_EOL;
+    }
+
+    $connection->unsubscribe($subscription->subscriptionId);
+}
+
+$connection->close();

--- a/example/tls.php
+++ b/example/tls.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use EJTJ3\PhpNats\Connection\NatsConnection;
+use EJTJ3\PhpNats\Connection\NatsConnectionOption;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// Use the tls:// scheme to enable TLS encryption
+$dsn = 'tls://admin:admin@nats-server.example.com:4222';
+
+$option = new NatsConnectionOption($dsn, 'tls example', 5);
+$connection = new NatsConnection($option);
+
+// TLS handshake will be performed automatically during connect
+$connection->connect();
+
+if ($connection->isConnected()) {
+    $connection->publish('secure.subject', 'encrypted payload');
+}
+
+$connection->close();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,30 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         verbose="true"
+         cacheDirectory="build/.phpunit.cache"
 >
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
+    </source>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/src/Connection/Error.php
+++ b/src/Connection/Error.php
@@ -6,4 +6,13 @@ namespace EJTJ3\PhpNats\Connection;
 
 final class Error implements NatsResponseInterface
 {
+    public function __construct(
+        private readonly string $message = '',
+    ) {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
 }

--- a/src/Connection/HMsg.php
+++ b/src/Connection/HMsg.php
@@ -50,13 +50,45 @@ final class HMsg implements MessageInterface
         $this->payload = $payload;
     }
 
+    /**
+     * @return array<string, string|int|null>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
     public function setHeaders(string $headers): void
     {
-        // Check if we have an inlined status.
-        $parts = explode(' ', $headers);
+        $lines = explode("\r\n", $headers);
+
+        // First line is the protocol line, e.g. "NATS/1.0 503" or "NATS/1.0"
+        $parts = explode(' ', $lines[0]);
 
         if (isset($parts[1]) && strlen($parts[1]) === 3) {
             $this->headers['status'] = (int) $parts[1];
+        }
+
+        // Remaining lines are key-value header pairs
+        for ($i = 1, $count = count($lines); $i < $count; ++$i) {
+            $line = trim($lines[$i]);
+
+            if ($line === '') {
+                continue;
+            }
+
+            $colonPos = strpos($line, ':');
+
+            if ($colonPos === false) {
+                continue;
+            }
+
+            $key = trim(substr($line, 0, $colonPos));
+            $value = trim(substr($line, $colonPos + 1));
+
+            if ($key !== '') {
+                $this->headers[$key] = $value;
+            }
         }
     }
 

--- a/src/Connection/Msg.php
+++ b/src/Connection/Msg.php
@@ -45,7 +45,7 @@ final class Msg implements MessageInterface
 
     public function getPayload(): string
     {
-        return $this->payload ?? '';
+        return $this->payload;
     }
 
     public function setPayload(string $payload): void

--- a/src/Connection/NatsConnection.php
+++ b/src/Connection/NatsConnection.php
@@ -10,10 +10,12 @@ use EJTJ3\PhpNats\Encoder\EncoderInterface;
 use EJTJ3\PhpNats\Encoder\JsonEncoder;
 use EJTJ3\PhpNats\Exception\NatsConnectionRefusedException;
 use EJTJ3\PhpNats\Exception\NatsInvalidResponseException;
+use EJTJ3\PhpNats\Exception\NatsReadException;
+use EJTJ3\PhpNats\Exception\NatsTimeoutException;
 use EJTJ3\PhpNats\Logger\NullLogger;
 use EJTJ3\PhpNats\Transport\NatsTransportInterface;
 use EJTJ3\PhpNats\Transport\Stream\StreamTransport;
-use EJTJ3\PhpNats\Transport\TranssportOption;
+use EJTJ3\PhpNats\Transport\TransportOption;
 use EJTJ3\PhpNats\Util\StringUtil;
 use Exception;
 use InvalidArgumentException;
@@ -78,7 +80,7 @@ final class NatsConnection implements LoggerAwareInterface
         }
 
         foreach ($this->connectionOptions->getServerCollection()->getServers() as $server) {
-            $transportOption = new TranssportOption(
+            $transportOption = new TransportOption(
                 host: $server->getHost(),
                 port: $server->getPort(),
                 timeout: $this->connectionOptions->getTimeout()
@@ -126,7 +128,28 @@ final class NatsConnection implements LoggerAwareInterface
 
     public function close(): void
     {
-        $this->transport->close();
+        if ($this->transport->isConnected()) {
+            $this->transport->close();
+        }
+
+        $this->connected = false;
+        $this->currentServer = null;
+        $this->serverInfo = null;
+
+        $this->logger->debug('Connection closed');
+    }
+
+    /**
+     * Reconnects by closing the current connection and trying all servers again.
+     *
+     * @throws Exception
+     */
+    public function reconnect(): void
+    {
+        $this->logger->debug('Attempting reconnect');
+
+        $this->close();
+        $this->connect();
     }
 
     public function setLogger(LoggerInterface $logger): void
@@ -163,6 +186,8 @@ final class NatsConnection implements LoggerAwareInterface
 
         $this->doWrite(NatsProtocolOperation::Pub, implode(' ', $content));
         $this->validateAcknowledgement();
+
+        $this->logger->debug(sprintf('Published %d bytes to "%s"', strlen($payload), $subject));
     }
 
     /**
@@ -256,14 +281,14 @@ final class NatsConnection implements LoggerAwareInterface
     }
 
     /**
-     * initiates a subscription to a subject, optionally joining a distributed queue group.
+     * Initiates a subscription to a subject, optionally joining a distributed queue group.
      *
-     * @param string|null $queueGroup if specified, the subscriber will join this queue group
      * @param string $subject the subject name to subscribe to
+     * @param string|null $queueGroup if specified, the subscriber will join this queue group
      *
      * @throws Exception
      */
-    private function subscribe(string $subject, ?string $queueGroup): Subscription
+    public function subscribe(string $subject, ?string $queueGroup = null): Subscription
     {
         $subscriptionId = self::createSid();
         $sub = new Subscription($subject, $subscriptionId);
@@ -278,16 +303,22 @@ final class NatsConnection implements LoggerAwareInterface
         $this->doWrite(NatsProtocolOperation::Sub, implode(' ', $payload));
         $this->validateAcknowledgement();
 
+        $this->logger->debug(sprintf('Subscribed to "%s" with sid "%s"', $subject, $subscriptionId));
+
         return $sub;
     }
 
     /**
+     * Unsubscribes from a subject by subscription ID.
+     *
      * @throws Exception
      */
-    private function unsubscribe(string $subscriptionId): void
+    public function unsubscribe(string $subscriptionId): void
     {
         $this->doWrite(NatsProtocolOperation::Unsub, $subscriptionId);
         $this->validateAcknowledgement();
+
+        $this->logger->debug(sprintf('Unsubscribed from sid "%s"', $subscriptionId));
     }
 
     /**
@@ -309,7 +340,7 @@ final class NatsConnection implements LoggerAwareInterface
             $read = $this->transport->read($chunkSize, Nats::CR_LF);
 
             if ($read === false) {
-                throw new Exception('Could not read from stream');
+                throw new NatsReadException('Could not read from stream');
             }
 
             if (is_string($read)) {
@@ -326,7 +357,7 @@ final class NatsConnection implements LoggerAwareInterface
             }
 
             if (microtime(true) >= $timeoutTarget) {
-                throw new InvalidArgumentException('Timeout reached');
+                throw new NatsTimeoutException('Timeout reached');
             }
         }
 
@@ -362,43 +393,54 @@ final class NatsConnection implements LoggerAwareInterface
         return $serverInfoMsg;
     }
 
+    private const MAX_PING_RETRIES = 10;
+
     /**
+     * Reads and returns the next message from the server.
+     *
      * @throws Exception
      */
-    private function getMsg(): NatsResponseInterface
+    public function getMsg(): NatsResponseInterface
     {
-        $line = $this->saveRead(0, 300);
+        $pingRetries = 0;
 
-        $response = Response::parse($line);
+        while (true) {
+            $line = $this->saveRead(0, 300);
 
-        if ($response instanceof Ping) {
-            $this->pong();
+            $response = Response::parse($line);
 
-            // @TODO add check for infinite loop
-            return $this->getMsg();
+            if ($response instanceof Ping) {
+                $this->pong();
+
+                if (++$pingRetries >= self::MAX_PING_RETRIES) {
+                    throw new NatsInvalidResponseException('Exceeded maximum number of PING retries');
+                }
+
+                continue;
+            }
+
+            if ($response instanceof ServerInfo || $response instanceof Pong || $response instanceof Acknowledgement || $response instanceof Error) {
+                return $response;
+            }
+
+            if ($response instanceof Msg) {
+                $payload = $this->saveRead($response->bytes);
+                $response->setPayload($payload);
+
+                return $response;
+            }
+
+            if ($response instanceof HMsg) {
+                $headers = $this->saveRead($response->headerBytes);
+                $response->setHeaders($headers);
+                $payload = $this->saveRead($response->totalBytes - $response->headerBytes);
+                $response->setPayload($payload);
+
+                return $response;
+            }
+
+            throw new LogicException('Msg type is not yet implemented');
         }
-
-        if ($response instanceof ServerInfo || $response instanceof Pong || $response instanceof Acknowledgement || $response instanceof Error) {
-            return $response;
-        }
-
-        if ($response instanceof Msg) {
-            $payload = $this->saveRead($response->bytes);
-            $response->setPayload($payload);
-
-            return $response;
-        }
-
-        if ($response instanceof HMsg) {
-            $headers = $this->saveRead($response->headerBytes);
-            $response->setHeaders($headers);
-            $payload = $this->saveRead($response->totalBytes - $response->headerBytes);
-            $response->setPayload($payload);
-
-            return $response;
-        }
-
-        throw new LogicException('Msg type is not yet implemented');
     }
 
     /**

--- a/src/Connection/Response.php
+++ b/src/Connection/Response.php
@@ -24,8 +24,11 @@ final class Response
             return new Acknowledgement();
         }
 
-        if (NatsProtocolOperation::Err->isOperation($payload)) {
-            return new Error();
+        if (str_starts_with($payload, NatsProtocolOperation::Err->value)) {
+            $message = trim(substr($payload, strlen(NatsProtocolOperation::Err->value)));
+            $message = trim($message, " '\"");
+
+            return new Error($message);
         }
 
         if (!str_contains($payload, ' ')) {

--- a/src/Connection/ServerInfo.php
+++ b/src/Connection/ServerInfo.php
@@ -99,7 +99,7 @@ final class ServerInfo implements NatsResponseInterface
          *     auth_required: bool|null,
          *     connect_urls: array<string>|null,
          *     client_id: int|null,
-         *     ldm: boolean|null,
+         *     ldm: bool|null,
          * } $content
          */
         $content = json_decode($response, true);

--- a/src/Exception/NatsReadException.php
+++ b/src/Exception/NatsReadException.php
@@ -6,6 +6,6 @@ namespace EJTJ3\PhpNats\Exception;
 
 use RuntimeException;
 
-final class NatsReadException extends RuntimeException
+final class NatsReadException extends RuntimeException implements NatsExceptionInterface
 {
 }

--- a/src/Exception/NatsTimeoutException.php
+++ b/src/Exception/NatsTimeoutException.php
@@ -6,6 +6,6 @@ namespace EJTJ3\PhpNats\Exception;
 
 use RuntimeException;
 
-final class NatsTimeoutException extends RuntimeException
+final class NatsTimeoutException extends RuntimeException implements NatsExceptionInterface
 {
 }

--- a/src/Transport/Stream/StreamTransport.php
+++ b/src/Transport/Stream/StreamTransport.php
@@ -90,7 +90,7 @@ final class StreamTransport implements NatsTransportInterface
         if (!stream_socket_enable_crypto(
             $this->getStream(),
             true,
-            STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
+            STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT
         )) {
             throw new NatsConnectionRefusedException('Failed to connect: Error negotiating crypto');
         }

--- a/src/Transport/TransportOption.php
+++ b/src/Transport/TransportOption.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EJTJ3\PhpNats\Transport;
 
-final class TranssportOption implements TransportOptionsInterface
+final class TransportOption implements TransportOptionsInterface
 {
     public function __construct(
         private readonly string $host,

--- a/tests/Connection/ClientConnectionOptionsTest.php
+++ b/tests/Connection/ClientConnectionOptionsTest.php
@@ -155,7 +155,7 @@ final class ClientConnectionOptionsTest extends TestCase
         $this->assertSame($expected, $options->toArray());
     }
 
-    public function createClientConnectionOptions(): Generator
+    public static function createClientConnectionOptions(): Generator
     {
         yield [new ClientConnectionOptions()];
     }

--- a/tests/Connection/ErrorTest.php
+++ b/tests/Connection/ErrorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Connection;
+
+use EJTJ3\PhpNats\Connection\Error;
+use EJTJ3\PhpNats\Connection\NatsResponseInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorTest extends TestCase
+{
+    public function testErrorWithMessage(): void
+    {
+        $error = new Error('Unknown Protocol Operation');
+
+        $this->assertSame('Unknown Protocol Operation', $error->getMessage());
+        $this->assertInstanceOf(NatsResponseInterface::class, $error);
+    }
+
+    public function testErrorWithoutMessage(): void
+    {
+        $error = new Error();
+
+        $this->assertSame('', $error->getMessage());
+    }
+}

--- a/tests/Connection/HMsgTest.php
+++ b/tests/Connection/HMsgTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Connection;
+
+use EJTJ3\PhpNats\Connection\HMsg;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class HMsgTest extends TestCase
+{
+    public function testCreateWithoutReplyTo(): void
+    {
+        $msg = HMsg::create('subject abc123 10 20');
+
+        $this->assertSame('subject', $msg->subject);
+        $this->assertSame('abc123', $msg->subscriptionId);
+        $this->assertNull($msg->replyTo);
+        $this->assertSame(10, $msg->headerBytes);
+        $this->assertSame(20, $msg->totalBytes);
+    }
+
+    public function testCreateWithReplyTo(): void
+    {
+        $msg = HMsg::create('subject abc123 reply.inbox 10 20');
+
+        $this->assertSame('subject', $msg->subject);
+        $this->assertSame('abc123', $msg->subscriptionId);
+        $this->assertSame('reply.inbox', $msg->replyTo);
+        $this->assertSame(10, $msg->headerBytes);
+        $this->assertSame(20, $msg->totalBytes);
+    }
+
+    public function testSetHeadersWithStatusOnly(): void
+    {
+        $msg = HMsg::create('subject abc123 10 20');
+
+        $msg->setHeaders("NATS/1.0 503\r\n");
+
+        $this->assertSame(503, $msg->getHeader('status'));
+    }
+
+    public function testSetHeadersWithKeyValuePairs(): void
+    {
+        $msg = HMsg::create('subject abc123 50 100');
+
+        $headers = "NATS/1.0 200\r\nX-Custom: value1\r\nX-Another: value2\r\n";
+
+        $msg->setHeaders($headers);
+
+        $this->assertSame(200, $msg->getHeader('status'));
+        $this->assertSame('value1', $msg->getHeader('X-Custom'));
+        $this->assertSame('value2', $msg->getHeader('X-Another'));
+    }
+
+    public function testSetHeadersWithoutStatus(): void
+    {
+        $msg = HMsg::create('subject abc123 50 100');
+
+        $headers = "NATS/1.0\r\nX-Custom: value\r\n";
+
+        $msg->setHeaders($headers);
+
+        $this->assertNull($msg->getHeader('status'));
+        $this->assertSame('value', $msg->getHeader('X-Custom'));
+    }
+
+    public function testGetHeaderReturnsNullForMissing(): void
+    {
+        $msg = HMsg::create('subject abc123 10 20');
+
+        $this->assertNull($msg->getHeader('nonexistent'));
+    }
+
+    public function testGetHeaders(): void
+    {
+        $msg = HMsg::create('subject abc123 50 100');
+
+        $headers = "NATS/1.0 200\r\nFoo: bar\r\n";
+        $msg->setHeaders($headers);
+
+        $allHeaders = $msg->getHeaders();
+
+        $this->assertSame(200, $allHeaders['status']);
+        $this->assertSame('bar', $allHeaders['Foo']);
+    }
+
+    public function testSetAndGetPayload(): void
+    {
+        $msg = HMsg::create('subject abc123 10 20');
+
+        $this->assertSame('', $msg->getPayload());
+
+        $msg->setPayload('hello');
+
+        $this->assertSame('hello', $msg->getPayload());
+    }
+
+    public function testCreateInvalidFormatThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        HMsg::create('subject');
+    }
+}

--- a/tests/Connection/MsgTest.php
+++ b/tests/Connection/MsgTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Connection;
+
+use EJTJ3\PhpNats\Connection\Msg;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class MsgTest extends TestCase
+{
+    public function testCreateWithoutReplyTo(): void
+    {
+        $msg = Msg::create('subject abc123 11');
+
+        $this->assertSame('subject', $msg->subject);
+        $this->assertSame('abc123', $msg->sid);
+        $this->assertNull($msg->replyTo);
+        $this->assertSame(11, $msg->bytes);
+    }
+
+    public function testCreateWithReplyTo(): void
+    {
+        $msg = Msg::create('subject abc123 reply.inbox 11');
+
+        $this->assertSame('subject', $msg->subject);
+        $this->assertSame('abc123', $msg->sid);
+        $this->assertSame('reply.inbox', $msg->replyTo);
+        $this->assertSame(11, $msg->bytes);
+    }
+
+    public function testSetAndGetPayload(): void
+    {
+        $msg = Msg::create('subject abc123 5');
+
+        $this->assertSame('', $msg->getPayload());
+
+        $msg->setPayload('hello');
+
+        $this->assertSame('hello', $msg->getPayload());
+    }
+
+    public function testCreateInvalidFormatThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Msg::create('subject');
+    }
+}

--- a/tests/Connection/NatsConnectionTest.php
+++ b/tests/Connection/NatsConnectionTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Connection;
+
+use EJTJ3\PhpNats\Connection\NatsConnection;
+use EJTJ3\PhpNats\Connection\NatsConnectionOption;
+use EJTJ3\PhpNats\Exception\NatsConnectionRefusedException;
+use EJTJ3\PhpNats\Transport\NatsTransportInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class NatsConnectionTest extends TestCase
+{
+    public function testConnectSuccessfully(): void
+    {
+        $serverInfoJson = json_encode([
+            'server_id' => 'test',
+            'version' => '2.0.0',
+            'host' => '0.0.0.0',
+            'port' => 4222,
+            'proto' => 1,
+            'max_payload' => 1048576,
+        ]);
+
+        $transport = $this->createMockTransport([
+            'INFO ' . $serverInfoJson, // server info
+            'PONG',                     // ping response
+        ]);
+
+        $options = new NatsConnectionOption('nats://localhost:4222');
+        $connection = new NatsConnection($options, $transport);
+
+        $connection->connect();
+
+        $this->assertTrue($connection->isConnected());
+        $this->assertNotNull($connection->getServerInfo());
+        $this->assertSame('test', $connection->getServerInfo()->getServerId());
+    }
+
+    public function testConnectAlreadyConnected(): void
+    {
+        $transport = $this->createMock(NatsTransportInterface::class);
+        $transport->method('isConnected')->willReturn(true);
+
+        $options = new NatsConnectionOption('nats://localhost:4222');
+        $connection = new NatsConnection($options, $transport);
+
+        // Should return early without error
+        $connection->connect();
+
+        $this->assertFalse($connection->isConnected());
+    }
+
+    public function testConnectNoServersAvailable(): void
+    {
+        $transport = $this->createMock(NatsTransportInterface::class);
+        $transport->method('isConnected')->willReturn(false);
+        $transport->method('connect')->willThrowException(
+            new NatsConnectionRefusedException('Connection refused')
+        );
+
+        $options = new NatsConnectionOption('nats://localhost:4222');
+        $connection = new NatsConnection($options, $transport);
+
+        $this->expectException(NatsConnectionRefusedException::class);
+        $this->expectExceptionMessage('nats: no servers available for connection');
+
+        $connection->connect();
+    }
+
+    public function testPublishWhenNotConnectedThrows(): void
+    {
+        $transport = $this->createMock(NatsTransportInterface::class);
+
+        $options = new NatsConnectionOption('nats://localhost:4222');
+        $connection = new NatsConnection($options, $transport);
+
+        $this->expectException(NatsConnectionRefusedException::class);
+        $this->expectExceptionMessage('Connection is closed');
+
+        $connection->publish('test', 'payload');
+    }
+
+    public function testSetNoRespondersWhenConnectedThrows(): void
+    {
+        $serverInfoJson = json_encode([
+            'server_id' => 'test',
+            'version' => '2.0.0',
+            'host' => '0.0.0.0',
+            'port' => 4222,
+            'proto' => 1,
+            'max_payload' => 1048576,
+        ]);
+
+        $transport = $this->createMockTransport([
+            'INFO ' . $serverInfoJson,
+            'PONG',
+        ]);
+
+        $options = new NatsConnectionOption('nats://localhost:4222');
+        $connection = new NatsConnection($options, $transport);
+        $connection->connect();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $connection->setNoResponders(true);
+    }
+
+    public function testSetVerboseWhenConnectedThrows(): void
+    {
+        $serverInfoJson = json_encode([
+            'server_id' => 'test',
+            'version' => '2.0.0',
+            'host' => '0.0.0.0',
+            'port' => 4222,
+            'proto' => 1,
+            'max_payload' => 1048576,
+        ]);
+
+        $transport = $this->createMockTransport([
+            'INFO ' . $serverInfoJson,
+            'PONG',
+        ]);
+
+        $options = new NatsConnectionOption('nats://localhost:4222');
+        $connection = new NatsConnection($options, $transport);
+        $connection->connect();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $connection->setVerbose(true);
+    }
+
+    public function testClose(): void
+    {
+        $serverInfoJson = json_encode([
+            'server_id' => 'test',
+            'version' => '2.0.0',
+            'host' => '0.0.0.0',
+            'port' => 4222,
+            'proto' => 1,
+            'max_payload' => 1048576,
+        ]);
+
+        $transport = $this->createMockTransport([
+            'INFO ' . $serverInfoJson,
+            'PONG',
+        ]);
+
+        $options = new NatsConnectionOption('nats://localhost:4222');
+        $connection = new NatsConnection($options, $transport);
+        $connection->connect();
+
+        $this->assertTrue($connection->isConnected());
+
+        $connection->close();
+
+        $this->assertFalse($connection->isConnected());
+    }
+
+    /**
+     * @param string[] $responses
+     */
+    private function createMockTransport(array $responses): NatsTransportInterface
+    {
+        $responseIndex = 0;
+        $connected = false;
+
+        $transport = $this->createMock(NatsTransportInterface::class);
+
+        $transport->method('isConnected')->willReturnCallback(
+            static function () use (&$connected): bool {
+                return $connected;
+            }
+        );
+
+        $transport->method('connect')->willReturnCallback(
+            static function () use (&$connected): void {
+                $connected = true;
+            }
+        );
+
+        $transport->method('close')->willReturnCallback(
+            static function () use (&$connected): void {
+                $connected = false;
+            }
+        );
+
+        $transport->method('read')->willReturnCallback(
+            static function () use ($responses, &$responseIndex): string|false {
+                if ($responseIndex >= count($responses)) {
+                    return false;
+                }
+
+                return $responses[$responseIndex++];
+            }
+        );
+
+        $transport->method('write');
+
+        return $transport;
+    }
+}

--- a/tests/Connection/ResponseTest.php
+++ b/tests/Connection/ResponseTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Connection;
+
+use EJTJ3\PhpNats\Connection\Acknowledgement;
+use EJTJ3\PhpNats\Connection\Error;
+use EJTJ3\PhpNats\Connection\HMsg;
+use EJTJ3\PhpNats\Connection\Msg;
+use EJTJ3\PhpNats\Connection\Ping;
+use EJTJ3\PhpNats\Connection\Pong;
+use EJTJ3\PhpNats\Connection\Response;
+use EJTJ3\PhpNats\Connection\ServerInfo;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ResponseTest extends TestCase
+{
+    public function testParsePong(): void
+    {
+        $response = Response::parse('PONG');
+
+        $this->assertInstanceOf(Pong::class, $response);
+    }
+
+    public function testParsePing(): void
+    {
+        $response = Response::parse('PING');
+
+        $this->assertInstanceOf(Ping::class, $response);
+    }
+
+    public function testParseAck(): void
+    {
+        $response = Response::parse('+OK');
+
+        $this->assertInstanceOf(Acknowledgement::class, $response);
+    }
+
+    public function testParseError(): void
+    {
+        $response = Response::parse("-ERR 'Unknown Protocol Operation'");
+
+        $this->assertInstanceOf(Error::class, $response);
+        $this->assertSame('Unknown Protocol Operation', $response->getMessage());
+    }
+
+    public function testParseErrorEmpty(): void
+    {
+        $response = Response::parse('-ERR');
+
+        $this->assertInstanceOf(Error::class, $response);
+        $this->assertSame('', $response->getMessage());
+    }
+
+    public function testParseMsg(): void
+    {
+        $response = Response::parse('MSG subject 1 5');
+
+        $this->assertInstanceOf(Msg::class, $response);
+        $this->assertSame('subject', $response->subject);
+        $this->assertSame('1', $response->sid);
+        $this->assertNull($response->replyTo);
+        $this->assertSame(5, $response->bytes);
+    }
+
+    public function testParseMsgWithReplyTo(): void
+    {
+        $response = Response::parse('MSG subject 1 reply.to 5');
+
+        $this->assertInstanceOf(Msg::class, $response);
+        $this->assertSame('subject', $response->subject);
+        $this->assertSame('1', $response->sid);
+        $this->assertSame('reply.to', $response->replyTo);
+        $this->assertSame(5, $response->bytes);
+    }
+
+    public function testParseHMsg(): void
+    {
+        $response = Response::parse('HMSG subject 1 10 20');
+
+        $this->assertInstanceOf(HMsg::class, $response);
+        $this->assertSame('subject', $response->subject);
+        $this->assertSame('1', $response->subscriptionId);
+        $this->assertNull($response->replyTo);
+        $this->assertSame(10, $response->headerBytes);
+        $this->assertSame(20, $response->totalBytes);
+    }
+
+    public function testParseHMsgWithReplyTo(): void
+    {
+        $response = Response::parse('HMSG subject 1 reply.to 10 20');
+
+        $this->assertInstanceOf(HMsg::class, $response);
+        $this->assertSame('subject', $response->subject);
+        $this->assertSame('1', $response->subscriptionId);
+        $this->assertSame('reply.to', $response->replyTo);
+        $this->assertSame(10, $response->headerBytes);
+        $this->assertSame(20, $response->totalBytes);
+    }
+
+    public function testParseInfo(): void
+    {
+        $json = json_encode([
+            'server_id' => 'test-id',
+            'version' => '2.0.0',
+            'go' => 'go1.19',
+            'host' => '0.0.0.0',
+            'port' => 4222,
+            'proto' => 1,
+            'max_payload' => 1048576,
+        ]);
+
+        $response = Response::parse('INFO ' . $json);
+
+        $this->assertInstanceOf(ServerInfo::class, $response);
+        $this->assertSame('test-id', $response->getServerId());
+        $this->assertSame('2.0.0', $response->getVersion());
+    }
+
+    public function testParseInvalidResponseThrowsException(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        Response::parse('INVALID');
+    }
+
+    public function testParseUnsupportedOperationThrowsException(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        Response::parse('UNKNOWN something');
+    }
+}

--- a/tests/Connection/ServerInfoTest.php
+++ b/tests/Connection/ServerInfoTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Connection;
+
+use EJTJ3\PhpNats\Connection\ServerInfo;
+use PHPUnit\Framework\TestCase;
+
+final class ServerInfoTest extends TestCase
+{
+    public function testFromDataMinimal(): void
+    {
+        $data = json_encode([
+            'server_id' => 'test-server',
+            'version' => '2.9.0',
+            'host' => '0.0.0.0',
+            'port' => 4222,
+            'proto' => 1,
+            'max_payload' => 1048576,
+        ]);
+
+        $info = ServerInfo::fromData($data);
+
+        $this->assertSame('test-server', $info->getServerId());
+        $this->assertSame('2.9.0', $info->getVersion());
+        $this->assertNull($info->getGoVersion());
+        $this->assertSame('0.0.0.0', $info->getHost());
+        $this->assertSame(4222, $info->getPort());
+        $this->assertSame(1, $info->getProto());
+        $this->assertSame(1048576, $info->getMaxPayload());
+        $this->assertFalse($info->isTlsRequired());
+        $this->assertFalse($info->isTlsVerified());
+        $this->assertFalse($info->isAuthRequired());
+        $this->assertSame([], $info->getConnectUrls());
+        $this->assertNull($info->getClientId());
+        $this->assertFalse($info->isLameDuckMode());
+    }
+
+    public function testFromDataFull(): void
+    {
+        $data = json_encode([
+            'server_id' => 'NATS-123',
+            'version' => '2.10.0',
+            'go' => 'go1.21',
+            'host' => '127.0.0.1',
+            'port' => 4223,
+            'proto' => 1,
+            'max_payload' => 8388608,
+            'tls_required' => true,
+            'tls_verify' => true,
+            'auth_required' => true,
+            'connect_urls' => ['nats://server1:4222', 'nats://server2:4222'],
+            'client_id' => 42,
+            'ldm' => true,
+        ]);
+
+        $info = ServerInfo::fromData($data);
+
+        $this->assertSame('NATS-123', $info->getServerId());
+        $this->assertSame('2.10.0', $info->getVersion());
+        $this->assertSame('go1.21', $info->getGoVersion());
+        $this->assertSame('127.0.0.1', $info->getHost());
+        $this->assertSame(4223, $info->getPort());
+        $this->assertSame(1, $info->getProto());
+        $this->assertSame(8388608, $info->getMaxPayload());
+        $this->assertTrue($info->isTlsRequired());
+        $this->assertTrue($info->isTlsVerified());
+        $this->assertTrue($info->isAuthRequired());
+        $this->assertSame(['nats://server1:4222', 'nats://server2:4222'], $info->getConnectUrls());
+        $this->assertSame(42, $info->getClientId());
+        $this->assertTrue($info->isLameDuckMode());
+    }
+}

--- a/tests/Transport/TransportOptionTest.php
+++ b/tests/Transport/TransportOptionTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Transport;
 
-use EJTJ3\PhpNats\Transport\TranssportOption;
+use EJTJ3\PhpNats\Transport\TransportOption;
 use PHPUnit\Framework\TestCase;
 
 final class TransportOptionTest extends TestCase
 {
     public function testTransportOption(): void
     {
-        $option = new TranssportOption('host', 9222, 5);
+        $option = new TransportOption('host', 9222, 5);
 
         $this->assertSame(5, $option->getTimeout());
         $this->assertSame('host', $option->getHost());


### PR DESCRIPTION
## Summary

- **Fix `TranssportOption` typo** — renamed class and file to `TransportOption`, updated all references
- **Fix infinite recursion risk** in `NatsConnection::getMsg()` — replaced recursion with loop + max 10 PING retry guard
- **Add TLS 1.3 support** alongside TLS 1.2 in `StreamTransport`
- **Complete HMsg header parsing** — now parses full key-value header pairs, not just status code
- **Make subscribe/unsubscribe/getMsg public** — enables long-lived subscriptions
- **Add `reconnect()` method** with proper state reset in `close()`
- **Improve logging** — added debug logging for publish, subscribe, unsubscribe, and close
- **Use proper exceptions** — `NatsReadException` and `NatsTimeoutException` now thrown where appropriate; `Error` class carries the error message
- **Upgrade PHPUnit 9 to 10** — updated config, fixed deprecated static data provider
- **Add PHPStan + php-cs-fixer to CI** — multi-job workflow with PHP version matrix (8.1–8.4)
- **Add `friendsofphp/php-cs-fixer`** as dev dependency with composer scripts (`cs-check`, `cs-fix`, `phpstan`)
- **Add 36 new tests** for `Response`, `ServerInfo`, `Msg`, `HMsg`, `Error`, and `NatsConnection` (30 → 66 tests)
- **Add example scripts** for request-response, subscribe, cluster, and TLS
- **Fix pre-existing PHPStan errors** (`boolean` → `bool`, unnecessary `isset`, unnecessary null coalesce)

## Test plan

- [x] All 66 tests pass (PHPUnit 10)
- [x] PHPStan max level — 0 errors
- [x] PHP CS Fixer — 0 violations
- [ ] Verify CI pipeline runs all three jobs (tests, phpstan, cs-check)
- [ ] Smoke test with a live NATS server (connect, publish, subscribe, request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)