### PR TITLE
fix: rename TranssportOption to TransportOption

### DIFF
--- a/src/Connection/NatsConnection.php
+++ b/src/Connection/NatsConnection.php
@@ -13,7 +13,7 @@ use EJTJ3\PhpNats\Exception\NatsInvalidResponseException;
 use EJTJ3\PhpNats\Logger\NullLogger;
 use EJTJ3\PhpNats\Transport\NatsTransportInterface;
 use EJTJ3\PhpNats\Transport\Stream\StreamTransport;
-use EJTJ3\PhpNats\Transport\TranssportOption;
+use EJTJ3\PhpNats\Transport\TransportOption;
 use EJTJ3\PhpNats\Util\StringUtil;
 use Exception;
 use InvalidArgumentException;
@@ -78,7 +78,7 @@ final class NatsConnection implements LoggerAwareInterface
         }
 
         foreach ($this->connectionOptions->getServerCollection()->getServers() as $server) {
-            $transportOption = new TranssportOption(
+            $transportOption = new TransportOption(
                 host: $server->getHost(),
                 port: $server->getPort(),
                 timeout: $this->connectionOptions->getTimeout()

--- a/src/Transport/TransportOption.php
+++ b/src/Transport/TransportOption.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EJTJ3\PhpNats\Transport;
 
-final class TranssportOption implements TransportOptionsInterface
+final class TransportOption implements TransportOptionsInterface
 {
     public function __construct(
         private readonly string $host,

--- a/tests/Transport/TransportOptionTest.php
+++ b/tests/Transport/TransportOptionTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Transport;
 
-use EJTJ3\PhpNats\Transport\TranssportOption;
+use EJTJ3\PhpNats\Transport\TransportOption;
 use PHPUnit\Framework\TestCase;
 
 final class TransportOptionTest extends TestCase
 {
     public function testTransportOption(): void
     {
-        $option = new TranssportOption('host', 9222, 5);
+        $option = new TransportOption('host', 9222, 5);
 
         $this->assertSame(5, $option->getTimeout());
         $this->assertSame('host', $option->getHost());


### PR DESCRIPTION
Fix TranssportOption typo — renamed class and file to TransportOption, updated all references

see #30
