### PR TITLE
feat: replace native streams with azjezz/psl for transport

### DIFF
--- a/.github/workflows/php-unit.yaml
+++ b/.github/workflows/php-unit.yaml
@@ -10,9 +10,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: php-actions/composer@v6
+        with:
+          php_version: 8.4
+          php_extensions: bcmath intl
 
       - name: PHPUnit Tests
         uses: php-actions/phpunit@v4
         with:
+          php_version: 8.4
           bootstrap: vendor/autoload.php
           configuration: phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,17 @@
         }
     ],
     "require": {
-        "php" : "^8.4",
+        "php": "^8.4",
         "nyholm/dsn": "^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "azjezz/psl": "^5.0"
+
     },
     "require-dev": {
         "phpunit/phpunit": "^11",
-        "phpstan/phpstan": "^2.0"
+        "phpstan/phpstan": "^2.0",
+        "friendsofphp/php-cs-fixer": "^3.0"
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/src/Connection/Error.php
+++ b/src/Connection/Error.php
@@ -6,4 +6,12 @@ namespace EJTJ3\PhpNats\Connection;
 
 final class Error implements NatsResponseInterface
 {
+    public function __construct(public string $message)
+    {
+    }
+
+    public static function parse(string $payload): self
+    {
+        return new self(substr($payload, 6, -1));
+    }
 }

--- a/src/Connection/NatsConnection.php
+++ b/src/Connection/NatsConnection.php
@@ -13,7 +13,6 @@ use EJTJ3\PhpNats\Exception\NatsInvalidResponseException;
 use EJTJ3\PhpNats\Logger\NullLogger;
 use EJTJ3\PhpNats\Transport\NatsTransportInterface;
 use EJTJ3\PhpNats\Transport\Stream\StreamTransport;
-use EJTJ3\PhpNats\Transport\TransportOption;
 use EJTJ3\PhpNats\Util\StringUtil;
 use Exception;
 use InvalidArgumentException;
@@ -78,14 +77,8 @@ final class NatsConnection implements LoggerAwareInterface
         }
 
         foreach ($this->connectionOptions->getServerCollection()->getServers() as $server) {
-            $transportOption = new TransportOption(
-                host: $server->getHost(),
-                port: $server->getPort(),
-                timeout: $this->connectionOptions->getTimeout()
-            );
-
             try {
-                $this->transport->connect($transportOption);
+                $this->transport->connect($server->getUrl(), $this->connectionOptions->getTimeout());
             } catch (Exception $e) {
                 $this->logger->error($e->getMessage());
 
@@ -112,9 +105,6 @@ final class NatsConnection implements LoggerAwareInterface
         }
 
         $this->doConnect();
-
-        // Validate PING response
-        $this->validatePing();
 
         $this->connected = true;
     }
@@ -206,13 +196,17 @@ final class NatsConnection implements LoggerAwareInterface
 
         $this->unsubscribe($sub->subscriptionId);
 
+        if ($msg instanceof Error) {
+            throw new NatsInvalidResponseException($msg->message);
+        }
+
         if (!$msg instanceof MessageInterface) {
             throw new InvalidArgumentException('Invalid response from nats');
         }
 
         if ($msg instanceof HMsg) {
             if ($msg->getHeader('status') === Nats::HEADER_NO_RESPONDER) {
-                throw new InvalidArgumentException('No responders are available');
+                throw new NatsInvalidResponseException('No responders are available');
             }
         }
 
@@ -293,44 +287,9 @@ final class NatsConnection implements LoggerAwareInterface
     /**
      * @throws Exception
      */
-    private function saveRead(int $maxBytes = 0, int $timeout = 100): string
+    private function saveRead(): string
     {
-        $line = '';
-        $timeoutTarget = microtime(true) + $timeout;
-        $receivedBytes = 0;
-        while ($receivedBytes < $maxBytes || $maxBytes === 0) {
-            $chunkSize = 1024;
-            $bytesLeft = ($maxBytes - $receivedBytes);
-
-            if ($maxBytes !== 0 && $bytesLeft < $chunkSize) {
-                $chunkSize = $bytesLeft;
-            }
-
-            $read = $this->transport->read($chunkSize, Nats::CR_LF);
-
-            if ($read === false) {
-                throw new Exception('Could not read from stream');
-            }
-
-            if (is_string($read)) {
-                $len = strlen($read);
-
-                $receivedBytes += $len;
-
-                $line .= $read;
-
-                // End of string is reached
-                if ($len < 1024) {
-                    break;
-                }
-            }
-
-            if (microtime(true) >= $timeoutTarget) {
-                throw new InvalidArgumentException('Timeout reached');
-            }
-        }
-
-        return $line;
+        return $this->transport->read() ?? '';
     }
 
     /**
@@ -367,7 +326,7 @@ final class NatsConnection implements LoggerAwareInterface
      */
     private function getMsg(): NatsResponseInterface
     {
-        $line = $this->saveRead(0, 300);
+        $line = $this->saveRead();
 
         $response = Response::parse($line);
 
@@ -383,16 +342,16 @@ final class NatsConnection implements LoggerAwareInterface
         }
 
         if ($response instanceof Msg) {
-            $payload = $this->saveRead($response->bytes);
+            $payload = $this->saveRead();
             $response->setPayload($payload);
 
             return $response;
         }
 
         if ($response instanceof HMsg) {
-            $headers = $this->saveRead($response->headerBytes);
+            $headers = $this->saveRead();
             $response->setHeaders($headers);
-            $payload = $this->saveRead($response->totalBytes - $response->headerBytes);
+            $payload = $this->saveRead();
             $response->setPayload($payload);
 
             return $response;

--- a/src/Connection/NatsConnectionOption.php
+++ b/src/Connection/NatsConnectionOption.php
@@ -6,6 +6,7 @@ namespace EJTJ3\PhpNats\Connection;
 
 use EJTJ3\PhpNats\Util\StringUtil;
 use InvalidArgumentException;
+use Psl\DateTime\Duration;
 
 final class NatsConnectionOption implements NatsConnectionOptionInterface
 {
@@ -75,8 +76,8 @@ final class NatsConnectionOption implements NatsConnectionOptionInterface
         return $this->serverCollection;
     }
 
-    public function getTimeout(): int
+    public function getTimeout(): Duration
     {
-        return $this->timeout;
+        return Duration::seconds($this->timeout);
     }
 }

--- a/src/Connection/NatsConnectionOptionInterface.php
+++ b/src/Connection/NatsConnectionOptionInterface.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace EJTJ3\PhpNats\Connection;
 
+use Psl\DateTime\Duration;
+
 interface NatsConnectionOptionInterface
 {
     public function getServerCollection(): ServerCollection;
 
-    public function getTimeout(): int;
+    public function getTimeout(): Duration;
 
     public function getName(): ?string;
 }

--- a/src/Connection/Response.php
+++ b/src/Connection/Response.php
@@ -25,7 +25,7 @@ final class Response
         }
 
         if (NatsProtocolOperation::Err->isOperation($payload)) {
-            return new Error();
+            return Error::parse($payload);
         }
 
         if (!str_contains($payload, ' ')) {

--- a/src/Connection/ServerInfo.php
+++ b/src/Connection/ServerInfo.php
@@ -7,80 +7,80 @@ namespace EJTJ3\PhpNats\Connection;
 /**
  * @see https://docs.nats.io/reference/reference-protocols/nats-protocol#info
  */
-final class ServerInfo implements NatsResponseInterface
+final readonly class ServerInfo implements NatsResponseInterface
 {
     public function __construct(
         /**
          * The unique identifier of the NATS server.
          */
-        private readonly string $serverId,
+        private string $serverId,
 
         /**
          * The version of the NATS server.
          */
-        private readonly string $version,
+        private string $version,
 
         /**
          * The version of golang the NATS server was built with.
          */
-        private readonly ?string $go,
+        private ?string $go,
 
         /**
          * The IP address used to start the NATS server,
          * by default this will be 0.0.0.0 and can be configured with -client_advertise host:port.
          */
-        private readonly string $host,
+        private string $host,
 
         /**
          * The port number the NATS server is configured to listen on.
          */
-        private readonly int $port,
+        private int $port,
 
         /**
          * An integer indicating the protocol version of the server.
          * The server version 1.2.0 sets this to 1 to indicate that it supports the "Echo" feature.
          */
-        private readonly int $proto,
+        private int $proto,
 
         /**
          * Maximum payload size, in bytes, that the server will accept from the client.
          */
-        private readonly int $maxPayload,
+        private int $maxPayload,
 
         /**
          * If this is set, then the client must perform the TLS/1.2 handshake.
          * Note, this used to be ssl_required and has been updated along with the protocol from SSL to TLS.
          */
-        private readonly bool $tlsRequired,
+        private bool $tlsRequired,
 
         /**
          *  If this is set, the client must provide a valid certificate during the TLS handshake.
          */
-        private readonly bool $tlsVerify,
+        private bool $tlsVerify,
 
         /**
          * If this is set, then the client should try to authenticate upon connect.
          */
-        private readonly bool $authRequired,
+        private bool $authRequired,
 
         /**
          * @var string[] $connectUrls
          *
          * An optional list of server urls that a client can connect to
          */
-        private readonly array $connectUrls,
+        private array $connectUrls,
 
         /**
          * An optional unsigned integer (64 bits) representing the internal client identifier in the server.
          * This can be used to filter client connections in monitoring, correlate with error logs, etc...
          */
-        private readonly ?int $clientId,
+        private ?int $clientId,
 
         /**
          * If the server supports Lame Duck Mode notifications,
          * and the current server has transitioned to lame duck, ldm will be set to true.
          */
-        private readonly bool $lameDuckMode,
+        private bool $lameDuckMode,
     ) {
     }
 
@@ -99,7 +99,7 @@ final class ServerInfo implements NatsResponseInterface
          *     auth_required: bool|null,
          *     connect_urls: array<string>|null,
          *     client_id: int|null,
-         *     ldm: boolean|null,
+         *     ldm: bool|null,
          * } $content
          */
         $content = json_decode($response, true);

--- a/src/Constant/Nats.php
+++ b/src/Constant/Nats.php
@@ -6,17 +6,17 @@ namespace EJTJ3\PhpNats\Constant;
 
 abstract class Nats
 {
-    final public const DEFAULT_PORT = 4222;
+    final public const int DEFAULT_PORT = 4222;
 
-    final public const CR_LF = "\r\n";
+    final public const string CR_LF = "\r\n";
 
-    final public const LANG = 'php';
+    final public const string LANG = 'php';
 
-    final public const VERSION = '0.0.2';
+    final public const string VERSION = '0.0.2';
 
-    final public const HEADER_LINE = 'NATS/1.0';
+    final public const string HEADER_LINE = 'NATS/1.0';
 
-    final public const HEADER_STATUS_LENGTH = 3;
+    final public const int HEADER_STATUS_LENGTH = 3;
 
-    final public const HEADER_NO_RESPONDER = 503;
+    final public const int HEADER_NO_RESPONDER = 503;
 }

--- a/src/Constant/NatsProtocolOperation.php
+++ b/src/Constant/NatsProtocolOperation.php
@@ -94,6 +94,6 @@ enum NatsProtocolOperation: string
 
     public function isOperation(string $value): bool
     {
-        return $this->value === $value;
+        return $this->value === $value || str_starts_with($value, $this->value);
     }
 }

--- a/src/Transport/NatsTransportInterface.php
+++ b/src/Transport/NatsTransportInterface.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace EJTJ3\PhpNats\Transport;
 
 use EJTJ3\PhpNats\Constant\Nats;
+use Nyholm\Dsn\Configuration\Url;
+use Psl\DateTime\Duration;
 
 interface NatsTransportInterface
 {
-    public function connect(TransportOptionsInterface $option): void;
+    public function connect(Url $url, Duration $timeout): void;
 
     public function close(): void;
 
@@ -20,5 +22,5 @@ interface NatsTransportInterface
 
     public function write(string $payload): void;
 
-    public function read(int $length, string $lineEnding = Nats::CR_LF): bool|string;
+    public function read(string $lineEnding = Nats::CR_LF): ?string;
 }

--- a/src/Transport/Stream/StreamTransport.php
+++ b/src/Transport/Stream/StreamTransport.php
@@ -7,23 +7,34 @@ namespace EJTJ3\PhpNats\Transport\Stream;
 use EJTJ3\PhpNats\Constant\Nats;
 use EJTJ3\PhpNats\Exception\NatsConnectionRefusedException;
 use EJTJ3\PhpNats\Transport\NatsTransportInterface;
-use EJTJ3\PhpNats\Transport\TransportOptionsInterface;
-use Exception;
+use Nyholm\Dsn\Configuration\Url;
+use Psl\DateTime\Duration;
+use Psl\IO\Reader;
+use Psl\Network\StreamInterface;
+use Psl\TCP;
+use Psl\TLS;
+use Psl\TLS\ClientConfig;
+use Psl\TLS\Connector;
 
 final class StreamTransport implements NatsTransportInterface
 {
-    /**
-     * @var resource|null
-     */
-    private $stream;
+    private ?StreamInterface $stream;
 
-    public function __construct(
-        /**
-         * @var int<0, max> $chunkSize
-         */
-        private readonly int $chunkSize = 1024,
-    ) {
+    private ?Reader $reader;
+
+    private ?Duration $timeout;
+
+    /**
+     * @var non-empty-string|null
+     */
+    private ?string $host;
+
+    public function __construct()
+    {
         $this->stream = null;
+        $this->reader = null;
+        $this->timeout = null;
+        $this->host = null;
     }
 
     /**
@@ -31,8 +42,10 @@ final class StreamTransport implements NatsTransportInterface
      */
     public function close(): void
     {
-        fclose($this->getStream());
+        $this->stream?->close();
         $this->stream = null;
+        $this->host = null;
+        $this->timeout = null;
     }
 
     public function isClosed(): bool
@@ -45,103 +58,66 @@ final class StreamTransport implements NatsTransportInterface
         return $this->stream !== null;
     }
 
-    public function connect(TransportOptionsInterface $option): void
+    public function connect(Url $url, Duration $timeout): void
     {
-        // Params
-        $address = sprintf('%s:%d', $option->getHost(), $option->getPort());
-        $timeout = $option->getTimeout();
-        $context = stream_context_get_default();
+        $host = $url->getHost();
 
-        // Create stream
-        $errorCode = null;
-        $errorMessage = null;
-
-        set_error_handler(static fn () => true);
-
-        $stream = stream_socket_client(
-            $address,
-            $errorCode,
-            $errorMessage,
-            $timeout,
-            STREAM_CLIENT_CONNECT,
-            $context
-        );
-
-        restore_error_handler();
-
-        if ($stream === false) {
-            throw new NatsConnectionRefusedException(sprintf('Could not connect to %s with an timeout of %d secondes', $address, $timeout));
+        if ($host === '') {
+            throw new NatsConnectionRefusedException('Host cannot be empty');
         }
 
-        stream_set_timeout($stream, $timeout, 0);
-
-        $this->stream = $stream;
-    }
-
-    public function enableTls(): void
-    {
-        // Create stream
-        set_error_handler(static function ($errorCode, $errorMessage) {
-            restore_error_handler();
-
-            throw new NatsConnectionRefusedException(sprintf('Failed to connect: %s', $errorMessage));
-        });
-
-        if (!stream_socket_enable_crypto(
-            $this->getStream(),
-            true,
-            STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
-        )) {
-            throw new NatsConnectionRefusedException('Failed to connect: Error negotiating crypto');
+        $port = $url->getPort() ?? 4222;
+        if ($port < 0 || $port > 65535) {
+            throw new NatsConnectionRefusedException('Port must be a non-negative integer');
         }
 
-        restore_error_handler();
+        $this->host = $host;
+        $this->timeout = $timeout;
+        $this->stream = TCP\connect($host, $port, timeout: $timeout);
+        $this->reader = new Reader($this->stream);
     }
 
-    /**
-     * @throws Exception
-     */
     public function write(string $payload): void
     {
-        $length = strlen($payload);
+        $this->getStream()->writeAll($payload, $this->timeout);
+    }
 
-        if ($length === 0) {
-            return;
+    public function read(string $lineEnding = Nats::CR_LF): ?string
+    {
+        return $this->getReader()->readUntil($lineEnding);
+    }
+
+    private function getReader(): Reader
+    {
+        if ($this->reader === null) {
+            throw new NatsConnectionRefusedException('Stream does not exist, try reconnecting');
         }
 
-        do {
-            $written = @fwrite($this->getStream(), $payload, $this->chunkSize);
-
-            if ($written === false) {
-                throw new NatsStreamWriteException('Error sending data');
-            }
-
-            if ($written === 0) {
-                throw new NatsStreamWriteException('Broken pipe or closed connection');
-            }
-
-            $length -= $written;
-
-            if ($length > 0) {
-                $payload = substr($payload, 0 - $length);
-            }
-        } while ($length > 0);
+        return $this->reader;
     }
 
-    public function read(int $length, string $lineEnding = Nats::CR_LF): false|string
-    {
-        return stream_get_line($this->getStream(), $length, $lineEnding);
-    }
-
-    /**
-     * @return resource
-     */
-    private function getStream()
+    public function getStream(): StreamInterface
     {
         if ($this->stream === null) {
             throw new NatsConnectionRefusedException('Stream does not exist, try reconnecting');
         }
 
         return $this->stream;
+    }
+
+    public function enableTls(): void
+    {
+        $stream = $this->getStream();
+
+        if ($stream instanceof TLS\StreamInterface) {
+            return;
+        }
+
+        if ($this->host === null) {
+            throw new NatsConnectionRefusedException('Host not found');
+        }
+
+        $this->stream = new Connector(ClientConfig::default())->connect($stream, $this->host);
+        $this->reader = new Reader($this->stream);
     }
 }

--- a/src/Transport/TransportOption.php
+++ b/src/Transport/TransportOption.php
@@ -4,27 +4,24 @@ declare(strict_types=1);
 
 namespace EJTJ3\PhpNats\Transport;
 
-final class TransportOption implements TransportOptionsInterface
+use Nyholm\Dsn\Configuration\Url;
+use Psl\DateTime\Duration;
+
+final readonly class TransportOption implements TransportOptionsInterface
 {
     public function __construct(
-        private readonly string $host,
-        private readonly int $port,
-        private readonly int $timeout,
+        private Url $url,
+        private Duration $timeout,
     ) {
     }
 
-    public function getTimeout(): int
+    public function getTimeout(): Duration
     {
         return $this->timeout;
     }
 
-    public function getHost(): string
+    public function getUrl(): Url
     {
-        return $this->host;
-    }
-
-    public function getPort(): int
-    {
-        return $this->port;
+        return $this->url;
     }
 }

--- a/src/Transport/TransportOptionsInterface.php
+++ b/src/Transport/TransportOptionsInterface.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace EJTJ3\PhpNats\Transport;
 
+use Nyholm\Dsn\Configuration\Url;
+use Psl\DateTime\Duration;
+
 interface TransportOptionsInterface
 {
-    public function getTimeout(): int;
+    public function getUrl(): Url;
 
-    public function getHost(): string;
-
-    public function getPort(): ?int;
+    public function getTimeout(): Duration;
 }

--- a/tests/Connection/ClientConnectionOptionsTest.php
+++ b/tests/Connection/ClientConnectionOptionsTest.php
@@ -32,7 +32,7 @@ final class ClientConnectionOptionsTest extends TestCase
         $this->assertFalse($options->isPedantic());
     }
 
-     #[DataProvider('createClientConnectionOptions')]
+    #[DataProvider('createClientConnectionOptions')]
     public function testTlsRequired(ClientConnectionOptions $options): void
     {
         $options->setTlsRequired(true);
@@ -51,8 +51,8 @@ final class ClientConnectionOptionsTest extends TestCase
         $options->setAuthToken(null);
         $this->assertEmpty($options->getAuthToken());
     }
-    #[DataProvider('createClientConnectionOptions')]
 
+    #[DataProvider('createClientConnectionOptions')]
     public function testUser(ClientConnectionOptions $options): void
     {
         $options->setUser('admin');
@@ -101,7 +101,7 @@ final class ClientConnectionOptionsTest extends TestCase
         $options->setEcho(false);
         $this->assertFalse($options->isEcho());
     }
-    
+
     #[DataProvider('createClientConnectionOptions')]
     public function testToArray(ClientConnectionOptions $options): void
     {

--- a/tests/Connection/NatsConnectionOptionTest.php
+++ b/tests/Connection/NatsConnectionOptionTest.php
@@ -42,6 +42,6 @@ final class NatsConnectionOptionTest extends TestCase
         );
 
         $this->assertSame('Testing server', $options->getName());
-        $this->assertSame(15, $options->getTimeout());
+        $this->assertSame(15.0, $options->getTimeout()->getTotalSeconds());
     }
 }

--- a/tests/Transport/TransportOptionTest.php
+++ b/tests/Transport/TransportOptionTest.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Transport;
 
 use EJTJ3\PhpNats\Transport\TransportOption;
+use Nyholm\Dsn\DsnParser;
 use PHPUnit\Framework\TestCase;
+use Psl\DateTime\Duration;
 
 final class TransportOptionTest extends TestCase
 {
     public function testTransportOption(): void
     {
-        $option = new TransportOption('host', 9222, 5);
+        $option = new TransportOption(
+            DsnParser::parseUrl('nats://host:9222'),
+            Duration::seconds(5),
+        );
 
-        $this->assertSame(5, $option->getTimeout());
-        $this->assertSame('host', $option->getHost());
-        $this->assertSame(9222, $option->getPort());
+        $this->assertSame(5.0, $option->getTimeout()->getTotalSeconds());
+        $this->assertNotNull($option->getUrl());
     }
 }


### PR DESCRIPTION
Updates the NATS client transport layer to use azjezz/psl primitives and shifts connection configuration to nyholm/dsn URLs and psl/datetime durations.

Changes:

Replace native PHP stream/socket usage with PSL TCP/TLS streams and readers in StreamTransport.
Refactor transport/connection option APIs to use Nyholm\Dsn\Configuration\Url and Psl\DateTime\Duration (including interface changes).
Adjust response/error parsing and update tests, Composer dependencies, and CI workflow PHP setup.